### PR TITLE
Allow JumpCloud users who use multi tenant accounts to integrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ wget https://github.com/lbrictson/wazuh-jumpcloud-integration/releases/download/
 wget https://raw.githubusercontent.com/lbrictson/wazuh-jumpcloud-integration/master/config/config.json -O /opt/jumpcloud/config.json
 # Place your JumpCloud API Key in the config file
 sed -i 's/this-is-not-a-real-key/YOUR-JUMPCLOUD-API-KEY-HERE/g' /opt/jumpcloud/config.json
+# Note if you are running JumpCloud in multi tenant mode you will also need to include your org_id in the config file
+# Reference this document:  https://docs.jumpcloud.com/api/1.0/index.html#section/Multi-Tenant-Portal-Headers
+# To add your org id (again only if multi tenant) open the config file with your favorite editor (vi in this case) and fill in the org_id field
+vi /opt/jumpcloud/config.json
 # Setup permissions
 chmod +x /opt/jumpcloud/wazuh-jumpcloud-integration
 chown -R root:wazuh /opt/jumpcloud

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -20,6 +20,7 @@ func main() {
 	jcAPI := pkg.NewJumpCloudAPI(pkg.NewJumpCloudAPIOptions{
 		APIKey:  conf.APIKey,
 		BaseURL: conf.BaseURL,
+		OrgID:   conf.OrgID,
 	})
 	err = pkg.RunService(conf, jcAPI, os.Args[2])
 	if err != nil {

--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,5 @@
 {
   "api_key":"this-is-not-a-real-key",
-  "base_url":"https://api.jumpcloud.com"
+  "base_url":"https://api.jumpcloud.com",
+  "org_id": ""
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -9,6 +9,7 @@ import (
 type ConfigurationData struct {
 	APIKey  string     `json:"api_key"`
 	BaseURL string     `json:"base_url"`
+	OrgID   string     `json:"org_id"`
 	Last    *time.Time `json:"last"`
 	path    string     `json:"-"`
 }

--- a/pkg/jumpcloud_api.go
+++ b/pkg/jumpcloud_api.go
@@ -62,6 +62,9 @@ func (a *JumpCloudAPI) GetEventsSinceTime(startTime time.Time) (*JumpCloudEvents
 	}
 	req.Header.Add("x-api-key", a.apiKey)
 	req.Header.Add("Content-Type", "application/json")
+	if a.orgID != "" {
+		req.Header.Add("x-org-id", a.orgID)
+	}
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %v", err)

--- a/pkg/jumpcloud_api.go
+++ b/pkg/jumpcloud_api.go
@@ -24,12 +24,14 @@ import (
 type JumpCloudAPI struct {
 	apiKey  string
 	baseURL string
+	orgID   string
 }
 
 // NewJumpCloudAPIOptions are the options for creating a new JumpCloudAPI object
 type NewJumpCloudAPIOptions struct {
 	APIKey  string
 	BaseURL string
+	OrgID   string
 }
 
 // NewJumpCloudAPI returns a new JumpCloudAPI object, if you do not provide a base URL, it will default to the JumpCloud API
@@ -37,6 +39,7 @@ func NewJumpCloudAPI(options NewJumpCloudAPIOptions) *JumpCloudAPI {
 	a := JumpCloudAPI{
 		apiKey:  options.APIKey,
 		baseURL: options.BaseURL,
+		orgID:   options.OrgID,
 	}
 	if options.BaseURL == "" {
 		a.baseURL = "https://api.jumpcloud.com"


### PR DESCRIPTION
Allow for multi tenant accounts to be used via the org_id header