### PR TITLE
Work-around to support @version values as numbers and strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 tmp/
 .idea
+.envrc
+.direnv

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+NAMES=iamtf josso
+VERSION=$(shell git describe --tags --always --dirty)
+
+PLATFORMS=darwin linux windows openbsd
+ARCHITECTURES=amd64 386 arm64 arm
+
+default: build
+
+dep: # Download required dependencies
+	go mod tidy
+	go mod vendor
+
+build:
+	CGO_ENABLED=0 go build -o ./tmp/wazuh-jumpcloud-integration -a -ldflags '-X main.version=$(VERSION) -extldflags "-static"' ./cmd/service/main.go
+
+#CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' .
+
+
+run: build
+	~/go/bin/custom-jumpcloud
+
+test: build
+	go test ./... -v
+
+dist:
+	$(foreach NAME,$(NAMES),\
+		$(foreach GOOS,$(PLATFORMS),\
+			$(foreach GOARCH,$(ARCHITECTURES),\
+				$(shell export GOOS=$(GOOS);\
+					export BINARY=$(NAME)ctl;\
+					export GOARCH=$(GOARCH);\
+					OUT_DIR='./.tmp/$(NAME)/$(GOOS)/$(GOARCH)/$(VERSION)';\
+					go build -ldflags "-X main.version=$(VERSION)" -v -o $${OUT_DIR%.}/$(BINARY) ./$(NAME)ctl; \
+					if test -f $${OUT_DIR}/$${BINARY} ; then cd $${OUT_DIR} ; zip -q ../../../$${BINARY}-$(GOOS)-$(GOARCH)-$(VERSION).zip $${BINARY} ; fi; \
+					if test -f $${OUT_DIR}/$${BINARY}.exe ; then cd $${OUT_DIR} ; zip -q ../../../$${BINARY}-$(GOOS)-$(GOARCH)-$(VERSION).zip $${BINARY}.exe ; fi \
+					))))

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,130 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "josso-pkgs": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1696390073,
+        "narHash": "sha256-UMbiNECb45HOgYiH3S3v5GP0b4XTidrWlNH2bvcm6/w=",
+        "owner": "sgonzalezoyuela",
+        "repo": "mynix-pkgs",
+        "rev": "10307ac450b267d62e9247bfb7b78b762cd181f0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sgonzalezoyuela",
+        "repo": "mynix-pkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1696323343,
+        "narHash": "sha256-u7WLUrh5eb+6SBYwtkaGL2ryHpLcHzmLml+a+VqKJWE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3b79cc4bcd9c09b5aa68ea1957c25e437dc6bc58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1706551096,
+        "narHash": "sha256-QLo6hsNpPv+skaQpuEvCKRgaA3i1U0F+CIl+SZGDKP4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0ea23c2c3792b92fe97535ef62d9a911eac9f250",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "josso-pkgs": "josso-pkgs",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+# JOSSO development environment: tools to work with JOSSO/IAM.tf
+
+{
+  description = "JOSSO/IAM.tf GO project flake";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    josso-pkgs.url = "github:sgonzalezoyuela/mynix-pkgs";
+  };
+  outputs = { self, nixpkgs, flake-utils, josso-pkgs }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+
+          pkgs = import nixpkgs {
+            inherit  system;
+            config = {
+              allowUnfree = true;
+            };
+          };
+ 
+
+        in
+        with pkgs;
+        {
+          devShells.default = mkShell {
+            buildInputs = [
+              gnumake
+              go
+              gotools
+              gopls
+              go-outline
+              gocode
+              gopkgs
+              gocode-gomod
+              godef
+              golint
+              gofumpt
+              terraform
+            ];
+            shellHook = ''
+              echo "JOSSO/IAM.tf GO environment"
+              echo " - ${pkgs.go.name}"
+              echo " - ${terraform.name}"
+              echo " - ${gnumake.name}"
+            '';
+          };
+        }
+      );
+}


### PR DESCRIPTION
JumpCloud is sending some of the events with @version: 0, while others use @version: "1" .  This work-around supports both options. 

We also provide a basic Makefile to build the binary with all libraries embedded, so there are no dependencies on the OS.

(flake.nix files are just to create a reproducible go-lang env, not mandatory)